### PR TITLE
Add window resizing support

### DIFF
--- a/main.js
+++ b/main.js
@@ -10,7 +10,7 @@ var canvas, ctx, width, height, CORNER, CENTER, CLOSE, LEFT, RIGHT, UP, DOWN, SQ
 canvas = document.getElementsByTagName('canvas')[0] ?? new OffscreenCanvas(window.innerWidth, window.innerHeight)
 ctx = canvas.getContext('2d')
 
-function resizeCanvas();
+function resizeCanvas() {
 	width = canvas.width = window.innerWidth
 	height = canvas.height = window.innerHeight
 }

--- a/main.js
+++ b/main.js
@@ -9,8 +9,13 @@ var canvas, ctx, width, height, CORNER, CENTER, CLOSE, LEFT, RIGHT, UP, DOWN, SQ
 //setup the canvas
 canvas = document.getElementsByTagName('canvas')[0] ?? new OffscreenCanvas(window.innerWidth, window.innerHeight)
 ctx = canvas.getContext('2d')
-width = canvas.width = window.innerWidth
-height = canvas.height = window.innerHeight
+
+function resizeCanvas();
+	width = canvas.width = window.innerWidth
+	height = canvas.height = window.innerHeight
+}
+resizeCanvas();
+window.onresize = resizeCanvas();
 
 //create constants
 CORNER = 0


### PR DESCRIPTION
Took the width/height/canvas.width/canvas.height, pulled it into a function, and called the function on window resize. This will make for more responsive game environments (the user resizes the game window while the game is in progress and doesn't have to then refresh it).

Totally fine if this code doesn't cut it, this is just an issue that I wanted to bring to attention and that I thought I could fix.